### PR TITLE
Modified record count check to allow single-record files

### DIFF
--- a/src/FastqParser.cpp
+++ b/src/FastqParser.cpp
@@ -134,7 +134,7 @@ bool FastqParser::Analyze(const FastqDataChunk& chunk_, FastqDatasetType& header
 		}
 	}
 
-	return recCount > 1;
+	return recCount > 0;
 }
 
 bool FastqParser::Analyze(const std::vector<FastqRecord>& records_, uint64 recCount_, bool estimateQualityOffset_, bool& isColorSpace_, uint32& qualityOffset_)
@@ -211,7 +211,7 @@ bool FastqParser::Analyze(const std::vector<FastqRecord>& records_, uint64 recCo
 		}
 	}
 
-	return recCount > 1;
+	return recCount > 0;
 }
 
 uint64 FastqParser::ParseFrom(const FastqDataChunk& chunk_, std::vector<FastqRecord>& records_, uint64& rec_count_, StreamsInfo& streamsInfo_)


### PR DESCRIPTION
I don't know the codebase well enough to be certain this is a bug, but modifying these lines now allows for handling of single-record inputs (see issue #13).